### PR TITLE
Update translations

### DIFF
--- a/commons-core/src/main/java/br/com/battlebits/commons/translate/TranslationCommon.java
+++ b/commons-core/src/main/java/br/com/battlebits/commons/translate/TranslationCommon.java
@@ -30,7 +30,15 @@ public class TranslationCommon {
     }
 
     public void addTranslation(DataTranslation dataTranslation) {
-        this.languageTranslations.putAll(dataTranslation.loadTranslations());
+        final Map<Language, Map<String, MessageFormat>> map = dataTranslation.loadTranslations();
+        map.forEach((language, messagesMap) -> {
+            if(languageTranslations.containsKey(language)) {
+                final Map<String, MessageFormat> messages = languageTranslations.get(language);
+                messagesMap.forEach(messages::put);
+            } else {
+                languageTranslations.put(language, messagesMap);
+            }
+        });
         this.enums.add(dataTranslation.getEnum());
     }
 


### PR DESCRIPTION
O método addTranslation estava sobrescrevendo as traduções anteriormente setadas, agora já é possível adicionar diferentes arquivos de tradução sem que ocorra esse problema.